### PR TITLE
Add works with Keepass 2 and Aegis

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,14 @@ Para ingreso manual: ingresar la clave Base32, y cambiar el período a 40 segund
 
 **KeePassXC**: Funciona ingresando manualmente la clave Base32 en Use Custom Settings. Seleccionar SHA-1, 40 segundos y 6 dígitos.
 
+**KeePass 2**: Funciona ingresando manualmente la clave Base32 
+en Edit Entry (Quick) → OTP Generator Settings... → Time-Based (TOTP). Período 40 segundos.
+O bien completando los campos especiales «TimeOtp-Secret-Base32» y «TimeOtp-Period» en Advanced → String fields.
+
+**Aegis Authenticator para Android**: No funciona con código QR.
+Para ingreso manual: ingresar la clave Base32, y cambiar el período a 40 segundos en Advanced Settings. 
+El indicador de tiempo representa el nuevo período.
+
 **Authy**: *No funciona.*
 
 <!-- (TODO: agregar instrucciones de cómo probar si una app es compatible) -->

--- a/banktoken/banelcotoken.py
+++ b/banktoken/banelcotoken.py
@@ -61,7 +61,7 @@ def fetch_encrypted_payload(bank_id, activation_code):
         if r.content == b'URL Incorrecta - contacte Soporte Security':
             raise RuntimeError("Got 'incorrect url' error - bad token?")
         else:
-            raise RuntimeError("Got unknown error")
+            raise RuntimeError("Got unknown error: %r" % r.content)
     else:
         raise RuntimeError("Got unexpected content type: %r" % content_type)
 


### PR DESCRIPTION
Funcionó para habilitar el token de Comafi, configurando el mismo en las aplicaciones Keepass 2 (PC) y Aegis Authenticator (Android). Desde el home banking funciona bien cuando lo solicita.

El código de asociación entregado por el cajero caduca pasados unos días si no se utiliza, y desde el script se recibe un error alusivo, "expired coupon".